### PR TITLE
Updates

### DIFF
--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -28,13 +28,6 @@ jobs:
                 repository: cvn/Dash-User-Contributions
                 token: ${{ secrets.DASH_REPO_TOKEN }}
                 path: Dash-User-Contributions
-            - name: Create brach
-              run: |
-                cd Dash-User-Contributions
-                git checkout -b tldr-pages-update
-                git push --force origin tldr-pages-update
-            - name: Check directory
-              run: pwd
             - name: Update version number in docset.json
               run: |
                 sed -i "s/\"version\": \".*\"/\"version\": \"$new_version\"/" Dash-User-Contributions/docsets/tldr/docset.json
@@ -45,6 +38,7 @@ jobs:
                 cd Dash-User-Contributions
                 git config user.name "github-actions[bot]"
                 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                git checkout -b tldr-pages-update
                 git add --all .
                 git commit -m "Update TLDR pages docset to $new_version"
-                git push
+                git push --force origin tldr-pages-update

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -19,10 +19,6 @@ jobs:
             - name: Build docset
               run: docker compose up
 
-    create-branch:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
             - name: Sync repo
               run: gh repo sync cvn/Dash-User-Contributions -b master --force
               env:

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -11,28 +11,41 @@ jobs:
         steps:
             - name: Create version environment variable
               run: echo "new_version=$(date -u +%Y-%m-%d)" >> $GITHUB_ENV
+
+
+            # Build docset
+
             - name: Checkout code
               uses: actions/checkout@v4
+
             - name: Set version number
               run: sed -i "s/YYYY-MM-DD/$new_version/" static/Info.plist
+
             - name: Build docset
               run: docker compose up
 
-            - name: Sync repo
+
+            # Create PR
+
+            - name: Sync contributions repo
               run: gh repo sync cvn/Dash-User-Contributions -b master --force
               env:
                 GITHUB_TOKEN: ${{ secrets.DASH_REPO_TOKEN }}
+
             - name: Checkout code
               uses: actions/checkout@v4
               with:
                 repository: cvn/Dash-User-Contributions
                 token: ${{ secrets.DASH_REPO_TOKEN }}
                 path: Dash-User-Contributions
+
             - name: Update version number in docset.json
               run: |
                 sed -i "s/\"version\": \".*\"/\"version\": \"$new_version\"/" Dash-User-Contributions/docsets/tldr/docset.json
+
             - name: Move docset
               run: mv tldr_pages.tgz Dash-User-Contributions/docsets/tldr/
+
             - name: Commit changes
               run: |
                 cd Dash-User-Contributions

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -32,7 +32,7 @@ jobs:
               run: |
                 cd Dash-User-Contributions
                 git checkout -b tldr-pages-update
-                git push origin tldr-pages-update
+                git push --force origin tldr-pages-update
             - name: Check directory
               run: pwd
             - name: Update version number in docset.json

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set version number
-              run: sed -i '' "s/YYYY-MM-DD/$new_version/" static/Info.plist
+              run: sed -i "s/YYYY-MM-DD/$new_version/" static/Info.plist
             - name: Build docset
               run: docker compose up
 

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -43,6 +43,8 @@ jobs:
             - name: Commit changes
               run: |
                 cd Dash-User-Contributions
+                git config user.name "github-actions[bot]"
+                git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                 git add --all .
                 git commit -m "Update TLDR pages docset to $new_version"
                 git push

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -55,3 +55,10 @@ jobs:
                 git add --all .
                 git commit -m "Update TLDR pages docset to $new_version"
                 git push --force origin tldr-update
+
+            - name: Create pull request to upstream
+              run: |
+                cd Dash-User-Contributions
+                gh pr create --head tldr-update --title "Update TLDR pages docset to $new_version" --body "This is an automated update created by [a workflow](https://github.com/cvn/tldr-python-dash-docset/actions/workflows/update-docset.yml)."
+              env:
+                GITHUB_TOKEN: ${{ secrets.DASH_REPO_TOKEN }}

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -5,13 +5,12 @@ on:
         - cron: '0 0 1 * *'
     workflow_dispatch:
 
-env:
-    new_version: $(date -u +"%Y-%m-%d")
-
 jobs:
     build:
         runs-on: ubuntu-latest
         steps:
+            - name: Create version environment variable
+              run: echo "new_version=$(date -u +%Y-%m-%d)" >> $GITHUB_ENV
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set version number

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -59,6 +59,10 @@ jobs:
             - name: Create pull request to upstream
               run: |
                 cd Dash-User-Contributions
-                gh pr create --head tldr-update --title "Update TLDR pages docset to $new_version" --body "This is an automated update created by [a workflow](https://github.com/cvn/tldr-python-dash-docset/actions/workflows/update-docset.yml)."
+                gh pr create \
+                  --repo Kapeli/Dash-User-Contributions \
+                  --head cvn/Dash-User-Contributions:tldr-update \
+                  --title "Update TLDR pages docset to $new_version" \
+                  --body "This is an automated update created by [a workflow](https://github.com/cvn/tldr-python-dash-docset/actions/workflows/update-docset.yml)."
               env:
                 GITHUB_TOKEN: ${{ secrets.DASH_REPO_TOKEN }}

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -1,4 +1,4 @@
-name: Monthly Update
+name: Update Docset
 
 on:
     schedule:
@@ -51,7 +51,7 @@ jobs:
                 cd Dash-User-Contributions
                 git config user.name "github-actions[bot]"
                 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                git checkout -b tldr-pages-update
+                git checkout -b tldr-update
                 git add --all .
                 git commit -m "Update TLDR pages docset to $new_version"
-                git push --force origin tldr-pages-update
+                git push --force origin tldr-update

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -5,6 +5,9 @@ on:
         - cron: '0 0 1 * *'
     workflow_dispatch:
 
+env:
+    new_version: $(date -u +"%Y-%m-%d")
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Set version number
-              run: sed -i '' "s/YYYY-MM-DD/$(date -u +"%Y-%m-%d")/" static/Info.plist
+              run: sed -i '' "s/YYYY-MM-DD/$new_version/" static/Info.plist
             - name: Build docset
               run: docker compose up
 
@@ -39,12 +42,12 @@ jobs:
               run: pwd
             - name: Update version number in docset.json
               run: |
-                sed -i 's/"version": ".*"/"version": "$(date +%Y-%m-%d)"/' Dash-User-Contributions/docsets/tldr/docset.json
+                sed -i 's/"version": ".*"/"version": "$new_version"/' Dash-User-Contributions/docsets/tldr/docset.json
             - name: Move docset
               run: mv tldr_pages.tgz Dash-User-Contributions/docsets/tldr/
             - name: Commit changes
               run: |
                 cd Dash-User-Contributions
                 git add --all .
-                git commit -m "Update TLDR pages docset to $(date +%Y-%m-%d)"
+                git commit -m "Update TLDR pages docset to $new_version"
                 git push

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -61,7 +61,7 @@ jobs:
                 cd Dash-User-Contributions
                 gh pr create \
                   --repo Kapeli/Dash-User-Contributions \
-                  --head cvn/Dash-User-Contributions:tldr-update \
+                  --head cvn:tldr-update \
                   --title "Update TLDR pages docset to $new_version" \
                   --body "This is an automated update created by [a workflow](https://github.com/cvn/tldr-python-dash-docset/actions/workflows/update-docset.yml)."
               env:

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -1,0 +1,51 @@
+name: Monthly Update
+
+on:
+    schedule:
+        - cron: '0 0 1 * *'
+    workflow_dispatch:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        container: docker/docker:latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Set version number
+              run: sed -i '' "s/YYYY-MM-DD/$(date -u +"%Y-%m-%d")/" static/Info.plist
+            - name: Build docset
+              run: docker compose up
+
+    create-branch:
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Sync repo
+              run: gh repo sync cvn/Dash-User-Contributions -b master --force
+              env:
+                GITHUB_TOKEN: ${{ secrets.DASH_REPO_TOKEN }}
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                repository: cvn/Dash-User-Contributions
+                token: ${{ secrets.DASH_REPO_TOKEN }}
+                path: Dash-User-Contributions
+            - name: Create brach
+              run: |
+                cd Dash-User-Contributions
+                git checkout -b tldr-pages-update
+                git push origin tldr-pages-update
+            - name: Check directory
+              run: pwd
+            - name: Update version number in docset.json
+              run: |
+                sed -i 's/"version": ".*"/"version": "$(date +%Y-%m-%d)"/' Dash-User-Contributions/docsets/tldr/docset.json
+            - name: Move docset
+              run: mv tldr_pages.tgz Dash-User-Contributions/docsets/tldr/
+            - name: Commit changes
+              run: |
+                cd Dash-User-Contributions
+                git add --all .
+                git commit -m "Update TLDR pages docset to $(date +%Y-%m-%d)"
+                git push

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -37,7 +37,7 @@ jobs:
               run: pwd
             - name: Update version number in docset.json
               run: |
-                sed -i 's/"version": ".*"/"version": "$new_version"/' Dash-User-Contributions/docsets/tldr/docset.json
+                sed -i "s/\"version\": \".*\"/\"version\": \"$new_version\"/" Dash-User-Contributions/docsets/tldr/docset.json
             - name: Move docset
               run: mv tldr_pages.tgz Dash-User-Contributions/docsets/tldr/
             - name: Commit changes

--- a/.github/workflows/update-docset.yml
+++ b/.github/workflows/update-docset.yml
@@ -8,7 +8,6 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
-        container: docker/docker:latest
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+RUN mkdir /code
+ADD requirements.txt /code/
+WORKDIR /code
+RUN pip install -r requirements.txt
+ADD . /code/
+
+CMD python generator.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3
 
 RUN mkdir /code
-ADD requirements.txt /code/
+COPY requirements.txt /code/
 WORKDIR /code
 RUN pip install -r requirements.txt
-ADD . /code/
+COPY . /code/
 
 CMD python generator.py

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ user manual.
 
 Thanks to [tldr.jsx][4] for your great CSS!
 
+### This is a fork
+
+The original author of this project, [Moddus](https://github.com/Moddus/tldr-python-dash-docset), appears to have abandoned it. This fork contains some [bug fixes and small improvements](https://github.com/Moddus/tldr-python-dash-docset/pull/5) to the original.
+
 ### Build
 
 If you have python 3 and the [required packages](requirements.txt):

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ user manual.
 
 Thanks to [tldr.jsx][4] for your great CSS!
 
+### Build
+
+If you have python 3 and the [required packages](requirements.txt):
+
+    python generator.py
+
+Or use Docker to create an environment and build:
+
+    docker-compose up
+
+
 [1]: http://kapeli.com/dash
 [2]: http://zealdocs.org/
 [3]: https://github.com/tldr-pages/tldr

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ If you have python 3 and the [required packages](requirements.txt):
 
 Or use Docker to create an environment and build:
 
-    docker-compose up
+    docker compose up
+
+### Updating Dash
+
+This repo has [a workflow](https://github.com/cvn/tldr-python-dash-docset/actions/workflows/update-docset.yml) that regularly updates the docset in Dash.
 
 
 [1]: http://kapeli.com/dash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+
+services:
+  builder:
+    build: .
+    volumes:
+      - .:/code

--- a/generator.py
+++ b/generator.py
@@ -48,7 +48,7 @@ cur.execute('CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TE
 cur.execute('CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path);')
 
 # Generate tldr pages to HTML documents
-markdowner = md.Markdown()
+markdowner = md.Markdown(extras=["code-friendly"])
 with zipfile.ZipFile(io.BytesIO(r.content), "r") as archive:
     for path in archive.namelist():
         if path.startswith(doc_pref) and path.endswith(".md"):

--- a/generator.py
+++ b/generator.py
@@ -21,7 +21,7 @@ docset_path        = "tldrpages.docset"
 doc_path_contents  = docset_path + "/Contents/"
 doc_path_resources = docset_path + "/Contents/Resources/"
 doc_path           = docset_path + "/Contents/Resources/Documents/"
-doc_pref           = "tldr-master/pages"
+doc_pref           = "tldr-master/pages/"
 
 if os.path.exists(doc_path):
     try: shutil.rmtree(doc_path)
@@ -53,7 +53,7 @@ with zipfile.ZipFile(io.BytesIO(r.content), "r") as archive:
     for path in archive.namelist():
         if path.startswith(doc_pref) and path.endswith(".md"):
             cmd_name = path[path.rfind("/")+1:-3]
-            sub_dir = path[len(doc_pref)+1:path.rfind("/")]
+            sub_dir = path[len(doc_pref):path.rfind("/")]
             sub_path = os.path.join(doc_path, sub_dir)
             if not os.path.exists(sub_path):
                 try: os.mkdir(sub_path)
@@ -68,7 +68,7 @@ with zipfile.ZipFile(io.BytesIO(r.content), "r") as archive:
             doc = markdowner.convert(archive.read(path))
             doc = re.sub(r'{{(.*?)}}', r'<em>\1</em>', doc)
             doc = html_tmpl.format(url=online_url+'/'+sub_dir+'/'+cmd_name+'.md', content=doc)
-            with open(os.path.join(doc_path, path[len(doc_pref)+1:].replace(".md", ".html")), "wb") as html:
+            with open(os.path.join(doc_path, path[len(doc_pref):].replace(".md", ".html")), "wb") as html:
                 html.write(doc.encode("utf-8"))
 db.commit()
 db.close()

--- a/generator.py
+++ b/generator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import requests as req, zipfile, io, markdown2 as md, sqlite3, os, shutil, tarfile
+import re
 
 html_tmpl = """<html><!-- Online page at {url} -->
     <head>
@@ -65,6 +66,7 @@ with zipfile.ZipFile(io.BytesIO(r.content), "r") as archive:
             else:
                 cur.execute('INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES (?,?,?)', (cmd_name, 'Command', sub_dir+'/'+cmd_name+".html"))
             doc = markdowner.convert(archive.read(path))
+            doc = re.sub(r'{{(.*?)}}', r'<em>\1</em>', doc)
             doc = html_tmpl.format(url=online_url+'/'+sub_dir+'/'+cmd_name, content=doc)
             with open(os.path.join(doc_path, path[len(doc_pref)+1:].replace(".md", ".html")), "wb") as html:
                 html.write(doc.encode("utf-8"))

--- a/generator.py
+++ b/generator.py
@@ -67,7 +67,7 @@ with zipfile.ZipFile(io.BytesIO(r.content), "r") as archive:
                 cur.execute('INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES (?,?,?)', (cmd_name, 'Command', sub_dir+'/'+cmd_name+".html"))
             doc = markdowner.convert(archive.read(path))
             doc = re.sub(r'{{(.*?)}}', r'<em>\1</em>', doc)
-            doc = html_tmpl.format(url=online_url+'/'+sub_dir+'/'+cmd_name, content=doc)
+            doc = html_tmpl.format(url=online_url+'/'+sub_dir+'/'+cmd_name+'.md', content=doc)
             with open(os.path.join(doc_path, path[len(doc_pref)+1:].replace(".md", ".html")), "wb") as html:
                 html.write(doc.encode("utf-8"))
 db.commit()

--- a/generator.py
+++ b/generator.py
@@ -2,8 +2,18 @@
 
 import requests as req, zipfile, io, markdown2 as md, sqlite3, os, shutil, tarfile
 
-html_tmpl = """<html><head><link rel="stylesheet" type="text/css" href="../style.css"/></head><body><section id="tldr"><div id="page">%content%</div></section></body></html>"""
+html_tmpl = """<html><!-- Online page at {url} -->
+    <head>
+        <link rel="stylesheet" type="text/css" href="../style.css"/>
+    </head>
+    <body>
+        <section id="tldr">
+            <div id="page">{content}</div>
+        </section>
+    </body>
+</html>"""
 
+online_url         = "https://github.com/tldr-pages/tldr/blob/master/pages"
 doc_source         = "https://github.com/tldr-pages/tldr/archive/master.zip"
 docset_path        = "tldrpages.docset"
 doc_path_contents  = docset_path + "/Contents/"
@@ -54,7 +64,7 @@ with zipfile.ZipFile(io.BytesIO(r.content), "r") as archive:
             else:
                 cur.execute('INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES (?,?,?)', (cmd_name, 'Command', sub_dir+'/'+cmd_name+".html"))
             doc = markdowner.convert(archive.read(path))
-            doc = html_tmpl.replace("%content%", doc)
+            doc = html_tmpl.format(url=online_url+'/'+sub_dir+'/'+cmd_name, content=doc)
             with open(os.path.join(doc_path, path[len(doc_pref)+1:].replace(".md", ".html")), "wb") as html:
                 html.write(doc.encode("utf-8"))
 db.commit()
@@ -62,7 +72,7 @@ db.close()
 
 # Generate tldr pages index.html
 with open(os.path.join(doc_path, "index.html"), "w+") as html:
-    html.write('<html><head></head><body><h1>TLDR pages Docset</h1><br/>powered by <a href="http://tldr-pages.github.io">tldr-pages.github.io/</a>')
+    html.write('<html><!-- Online page at '+online_url+' --><head></head><body><h1>TLDR pages Docset</h1><br/>powered by <a href="http://tldr-pages.github.io">tldr-pages.github.io/</a>')
     for dir in os.listdir(doc_path):
         if os.path.isdir(os.path.join(doc_path, dir)):
             html.write("<h2>%s</h2><ul>" % dir)

--- a/generator.py
+++ b/generator.py
@@ -73,10 +73,10 @@ db.close()
 # Generate tldr pages index.html
 with open(os.path.join(doc_path, "index.html"), "w+") as html:
     html.write('<html><!-- Online page at '+online_url+' --><head></head><body><h1>TLDR pages Docset</h1><br/>powered by <a href="http://tldr-pages.github.io">tldr-pages.github.io/</a>')
-    for dir in os.listdir(doc_path):
+    for dir in sorted(os.listdir(doc_path)):
         if os.path.isdir(os.path.join(doc_path, dir)):
             html.write("<h2>%s</h2><ul>" % dir)
-            html.writelines(['<li><a href="%s/%s">%s</a></li>' % (dir, f, f[:-5]) for f in os.listdir(os.path.join(doc_path, dir))])
+            html.writelines(['<li><a href="%s/%s">%s</a></li>' % (dir, f, f[:-5]) for f in sorted(os.listdir(os.path.join(doc_path, dir)))])
             html.write("</ul>")
     html.write('</body></html>')
 

--- a/generator.py
+++ b/generator.py
@@ -73,10 +73,10 @@ db.close()
 
 # Generate tldr pages index.html
 with open(os.path.join(doc_path, "index.html"), "w+") as html:
-    html.write('<html><!-- Online page at '+online_url+' --><head><meta charset="UTF-8"></head><body><h1>TLDR pages Docset</h1><br/>powered by <a href="http://tldr-pages.github.io">tldr-pages.github.io/</a>')
+    html.write('<html><!-- Online page at '+online_url+' --><head><meta charset="UTF-8"><title>TLDR pages</title></head><body><h1>TLDR pages</h1><br/>powered by <a href="http://tldr-pages.github.io">tldr-pages.github.io/</a>')
     for dir in sorted(os.listdir(doc_path)):
         if os.path.isdir(os.path.join(doc_path, dir)):
-            html.write("<h2>%s</h2><ul>" % dir)
+            html.write('<a name="//apple_ref/cpp/Section/{name}" class="dashAnchor"></a><h2>{name}</h2><ul>'.format(name=dir))
             html.writelines(['<li><a href="%s/%s">%s</a></li>' % (dir, f, f[:-5]) for f in sorted(os.listdir(os.path.join(doc_path, dir)))])
             html.write("</ul>")
     html.write('</body></html>')

--- a/generator.py
+++ b/generator.py
@@ -4,6 +4,7 @@ import requests as req, zipfile, io, markdown2 as md, sqlite3, os, shutil, tarfi
 
 html_tmpl = """<html><!-- Online page at {url} -->
     <head>
+        <meta charset="UTF-8">
         <link rel="stylesheet" type="text/css" href="../style.css"/>
     </head>
     <body>
@@ -72,7 +73,7 @@ db.close()
 
 # Generate tldr pages index.html
 with open(os.path.join(doc_path, "index.html"), "w+") as html:
-    html.write('<html><!-- Online page at '+online_url+' --><head></head><body><h1>TLDR pages Docset</h1><br/>powered by <a href="http://tldr-pages.github.io">tldr-pages.github.io/</a>')
+    html.write('<html><!-- Online page at '+online_url+' --><head><meta charset="UTF-8"></head><body><h1>TLDR pages Docset</h1><br/>powered by <a href="http://tldr-pages.github.io">tldr-pages.github.io/</a>')
     for dir in sorted(os.listdir(doc_path)):
         if os.path.isdir(os.path.join(doc_path, dir)):
             html.write("<h2>%s</h2><ul>" % dir)

--- a/generator.py
+++ b/generator.py
@@ -15,13 +15,13 @@ html_tmpl = """<html><!-- Online page at {url} -->
     </body>
 </html>"""
 
-online_url         = "https://github.com/tldr-pages/tldr/blob/master/pages"
-doc_source         = "https://github.com/tldr-pages/tldr/archive/master.zip"
+online_url         = "https://github.com/tldr-pages/tldr/blob/main/pages"
+doc_source         = "https://github.com/tldr-pages/tldr/archive/refs/heads/main.zip"
 docset_path        = "tldrpages.docset"
 doc_path_contents  = docset_path + "/Contents/"
 doc_path_resources = docset_path + "/Contents/Resources/"
 doc_path           = docset_path + "/Contents/Resources/Documents/"
-doc_pref           = "tldr-master/pages/"
+doc_pref           = "tldr-main/pages/"
 
 if os.path.exists(doc_path):
     try: shutil.rmtree(doc_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+markdown2

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.3.2</string>
+	<string>TLDR pages 0.0.3.3</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.3.7</string>
+	<string>TLDR pages YYYY-MM-DD</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.3.1</string>
+	<string>TLDR pages 0.0.3.2</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -12,5 +12,7 @@
 	<true/>
     <key>dashIndexFilePath</key>
     <string>index.html</string>
+	<key>DashDocSetFamily</key>
+	<string>dashtoc</string>
 </dict>
 </plist>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.3.0</string>
+	<string>TLDR pages 0.0.3.1</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.3.3</string>
+	<string>TLDR pages 0.0.3.4</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.3.6</string>
+	<string>TLDR pages 0.0.3.7</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.3.5</string>
+	<string>TLDR pages 0.0.3.6</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.3.4</string>
+	<string>TLDR pages 0.0.3.5</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/Info.plist
+++ b/static/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>TLDR pages 0.0.2.8</string>
+	<string>TLDR pages 0.0.3.0</string>
 	<key>CFBundleName</key>
 	<string>TLDR pages</string>
 	<key>DocSetPlatformFamily</key>

--- a/static/style.css
+++ b/static/style.css
@@ -7,6 +7,10 @@ body {
   background: #FEFEFE;
   color: #151515; }
 
+code em {
+  color: lightseagreen;
+  font-style: normal; }
+
 #tldr #page {
   margin-bottom: 4em;
   font-size: 1.25em;}

--- a/static/style.css
+++ b/static/style.css
@@ -7,41 +7,8 @@ body {
   background: #FEFEFE;
   color: #151515; }
 
-.github-corner {
-  border: 0;
-  fill: #FEFEFE;
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 99;
-  padding: 0.5em; }
-  @media only screen and (min-device-width: 1024px) and (min-device-height: 728px) {
-    .github-corner {
-      padding: 0.2em; } }
-
-#tldr #search-bar {
-  font-size: 1.5em;
-  background-color: #151515;
-  color: #FEFEFE;
-  padding: 0.5em;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%; }
-  #tldr #search-bar * {
-    font-family: "Source Code Pro", courier new, courier; }
-  #tldr #search-bar input, #tldr #search-bar input:focus {
-    border: none;
-    outline: none;
-    background-color: #151515;
-    color: #FEFEFE; }
-  @media only screen and (orientation: landscape) {
-    #tldr #search-bar {
-      font-size: 2em; } }
-  @media only screen and (min-device-width: 1024px) and (min-device-height: 728px) {
-    #tldr #search-bar {
-      font-size: 1em; } }
 #tldr #page {
+  margin-bottom: 4em;
   font-size: 1.25em;}
   #tldr #page p {
     margin: 0; }
@@ -54,9 +21,12 @@ body {
     font-family: "Source Code Pro", courier new, courier;
     background-color: #f2f2f2;
     color: #212121;
-    display: block;
-    padding: 0.55em 1.25em;
+    display: inline-block;
+    padding: 0.25em 0.5em; 
     margin: 0; }
+  #tldr #page > p code {
+    display: block;
+    padding: 0.55em 1.25em; }
   #tldr #page ul {
     list-style: none;
     padding: 0 !important;
@@ -67,10 +37,8 @@ body {
   @media only screen and (min-device-width: 1024px) {
     #tldr #page {
       font-size: 1em; }
-      #tldr #page code {
+      #tldr #page > p code {
         padding-left: 3em; }
         #tldr #page ul li:before {
           content: "*";
           padding: 0 12px; } }
-
-/*# sourceMappingURL=index.css.map */

--- a/static/style.css
+++ b/static/style.css
@@ -1,8 +1,6 @@
-* {
-  font-family: Helvetica Neue, Helvetica;
-  font-size: 1em; }
-
 body {
+  font-family: Helvetica Neue, Helvetica, sans-serif;
+  font-size: 16px;
   margin: 0;
   background: #FEFEFE;
   color: #151515; }
@@ -12,8 +10,7 @@ code em {
   font-style: normal; }
 
 #tldr #page {
-  margin-bottom: 4em;
-  font-size: 1.25em;}
+  margin-bottom: 4em; }
   #tldr #page p {
     margin: 0; }
   #tldr #page h1 {
@@ -22,7 +19,7 @@ code em {
   #tldr #page blockquote {
     margin: 0 0.55em; }
   #tldr #page code {
-    font-family: "Source Code Pro", courier new, courier;
+    font-family: "Source Code Pro", courier new, courier, monospace;
     background-color: #f2f2f2;
     color: #212121;
     display: inline-block;
@@ -30,7 +27,7 @@ code em {
     margin: 0; }
   #tldr #page > p code {
     display: block;
-    padding: 0.55em 1.25em; }
+    padding: 0.55em; }
   #tldr #page ul {
     list-style: none;
     padding: 0 !important;
@@ -39,10 +36,11 @@ code em {
       padding: 0.5em 0.55em;
       line-height: 1.1; }
   @media only screen and (min-device-width: 1024px) {
-    #tldr #page {
-      font-size: 1em; }
       #tldr #page > p code {
         padding-left: 3em; }
+      #tldr #page ul li {
+        padding-left: 3em; }
         #tldr #page ul li:before {
-          content: "*";
-          padding: 0 12px; } }
+          content: "–";
+          position: absolute;
+          margin-left: -1.5em; } }


### PR DESCRIPTION
Hi @Moddus,

I've been enjoying the TLDR pages docset. I wanted to create an updated version, and along the way I fixed a few issues with the generator, and added some features too. Here's a summary of the changes:

* update the styles (see example below)
    * support inline `code` elements ([csvcut](https://github.com/tldr-pages/tldr/blob/master/pages/common/csvcut.md))
    * style curly brackets as colored text (this should address issue #4)
    * replace asterisk with endash and make left padding consistent
* add support for [online redirection](https://kapeli.com/docsets#onlineRedirection), to make it easy to get to the source documents from Dash
* fix encoding issues e.g. thatâ€™s -> that’s ([ditto](https://github.com/tldr-pages/tldr/blob/master/pages/osx/ditto.md))
* fix underscore issues e.g. day_of_week -> day_of_week instead of day*of*week ([crontab](https://github.com/tldr-pages/tldr/blob/master/pages/common/crontab.md))
* add a [table of contents](https://kapeli.com/docsets#tableofcontents) to the index page
* make sure the index page is always in alphabetical order
* add config files for Docker and pip, to make it easier to get started, and lay a foundation for automated builds via CI

I plan to submit a new version to the Dash-User-Contributions repo in the next few days. If you would like to do that instead, just mention me in the PR so I know about it.

Let me know if you have any questions.

Chad

---
<img width="283" alt="screenshot 2018-02-12 15 22 41" src="https://user-images.githubusercontent.com/774864/36125448-dc12b1a8-1008-11e8-983b-27fd141ce921.png">