### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -4,7 +4,7 @@ import requests as req, zipfile, io, markdown2 as md, sqlite3, os, shutil, tarfi
 
 html_tmpl = """<html><head><link rel="stylesheet" type="text/css" href="../style.css"/></head><body><section id="tldr"><div id="page">%content%</div></section></body></html>"""
 
-doc_source         = "https://github.com/tldr-pages/tldr/archive/master.zip"
+doc_source         = "https://github.com/tldr-pages/tldr/archive/main.zip"
 docset_path        = "tldrpages.docset"
 doc_path_contents  = docset_path + "/Contents/"
 doc_path_resources = docset_path + "/Contents/Resources/"


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).

I am not sure about line 12, update it too if necessary.